### PR TITLE
Fixes "Installing" instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ iFORP is designed to help you prototype your web applications. You can upload ei
 
 - `git clone` this repository
 - `npm install` inside `backend/` and `frontend/`
-- `npm start` inside the project root
+- `npm install` inside the project root
+- `npm run start:dev` inside the project root
 
 The frontend gets served on port 3000 and the backend will listen on port 3001.
 🎉


### PR DESCRIPTION
Install for project root (for npm-run-all) missing. The call to the start script seems to be "start:dev" instead of "start".